### PR TITLE
Update to work with IntelliJ 14 and AppCode 3

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -26,11 +26,21 @@
          ]]>
     </description>
 
-    <version>0.2</version>
+    <version>0.3</version>
     <vendor url="http://www.echologic.com" email="derek@echologic.com">Derek Scherger</vendor>
     <change-notes>
         <![CDATA[
         <dl>
+
+        <dt><b>April 2, 2014 (Release 0.3)</b></dt>
+        <dd>
+        Updated to work with latest IntelliJ and AppCode
+        <dd>
+
+        <dt><b>June 6, 2011 (Release 0.2)</b></dt>
+        <dd>
+        Updated to work with AppCode
+        <dd>
 
         <dt><b>November 14, 2005 (Release 0.1)</b></dt>
         <dd>

--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,7 @@
 <project name="XFiles Plugin" default="all" basedir=".">
     <property file="build.properties"/>
     <property name="plugin.dir" value="."/>
-    <property name="idea.lib" value="${idea.dir}/lib"/>
+    <property name="idea.lib" value="${idea.dir}/Contents/lib"/>
 
     <property name="plugin.name" value="xfiles"/>
     <property name="build.debug" value="on"/>

--- a/src/com/echologic/xfiles/XFilesIcons.java
+++ b/src/com/echologic/xfiles/XFilesIcons.java
@@ -6,8 +6,8 @@
 package com.echologic.xfiles;
 
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 
+import com.intellij.icons.AllIcons;
 import com.intellij.util.Icons;
 
 /**
@@ -15,21 +15,17 @@ import com.intellij.util.Icons;
  */
 public abstract class XFilesIcons extends Icons {
 
-    public static final Icon SCROLL_TO_ICON = load("/general/autoscrollToSource.png");
-    public static final Icon SCROLL_FROM_ICON = load("/general/autoscrollFromSource.png");
-    public static final Icon REMOVE_ICON = load("/general/remove.png");
-    public static final Icon COPY_ICON = load("/general/copy.png");
+    public static final Icon SCROLL_TO_ICON = AllIcons.General.AutoscrollToSource;
+    public static final Icon SCROLL_FROM_ICON = AllIcons.General.AutoscrollFromSource;
+    public static final Icon REMOVE_ICON = AllIcons.General.Remove;
+    public static final Icon COPY_ICON = AllIcons.Actions.Copy;
 
-    public static final Icon DOWN_ICON = load("/actions/moveDown.png");
-    public static final Icon UP_ICON = load("/actions/moveUp.png");
-    public static final Icon SYNC_ICON = load("/actions/sync.png");
-    public static final Icon PROPERTIES_ICON = load("/actions/properties.png");
+    public static final Icon DOWN_ICON = AllIcons.Actions.MoveDown;
+    public static final Icon UP_ICON = AllIcons.Actions.MoveUp;
+    public static final Icon SYNC_ICON = AllIcons.Actions.Refresh;
+    public static final Icon PROPERTIES_ICON = AllIcons.Actions.Properties;
 
-    public static final Icon FILTER_ICON = load("/debugger/class_filter.png");
+    public static final Icon FILTER_ICON = AllIcons.Debugger.Class_filter;
 
-    public static final Icon XFILES_ICON = load("/objectBrowser/visibilitySort.png");
-
-    private static Icon load(String path) {
-        return new ImageIcon(XFilesIcons.class.getResource(path));
-    }
+    public static final Icon XFILES_ICON = AllIcons.ObjectBrowser.VisibilitySort;
 }


### PR DESCRIPTION
I decided to resurrect this old plugin since it stopped working a while back again. I just had to fix a build issue as well as update the way system icons are loaded.

I also had to specify `JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/1.6/Home` in my shell in order for `ant` to compile byte code compatible with IDEA's old 1.6 JRE.
